### PR TITLE
Clean up atomic swap implementation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,6 @@
 
 
 [[projects]]
-  branch = "alpes-permission-review"
   name = "github.com/confio/weave"
   packages = [
     ".",
@@ -19,7 +18,8 @@
     "x/sigs",
     "x/utils"
   ]
-  revision = "28a68fcaff08083b52c6c406cfe4f637d6a389b6"
+  revision = "ac1cf04ea790e0025eca432ae3ac36d1e5e42be4"
+  version = "v0.4.0"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -155,10 +155,7 @@
 
 [[projects]]
   name = "github.com/tendermint/go-wire"
-  packages = [
-    ".",
-    "data"
-  ]
+  packages = ["."]
   revision = "fa721242b042ecd4c6ed1a934ee740db4f74e45c"
   version = "v0.7.3"
 
@@ -257,6 +254,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6167e255a45311ba9ed16648515292d2ea0d3082846061afeed8fe61d3223a1e"
+  inputs-digest = "dfd363cd6543c20bc52f924559ceae313d2e7e5327b586e0b90c147f22d63ab2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  branch = "master"
+  branch = "alpes-permission-review"
   name = "github.com/confio/weave"
   packages = [
     ".",
@@ -19,7 +19,7 @@
     "x/sigs",
     "x/utils"
   ]
-  revision = "278f1b417c9f1a7c1323ef832f499e28acaa2325"
+  revision = "28a68fcaff08083b52c6c406cfe4f637d6a389b6"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -257,6 +257,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8fb1143ca2ce4cad072c7beaae7d0ad27ba97adb1b12d92e102ec25d11336210"
+  inputs-digest = "6167e255a45311ba9ed16648515292d2ea0d3082846061afeed8fe61d3223a1e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/confio/weave"
-  branch = "alpes-permission-review"
+  version = "0.4.0"
 
 [[constraint]]
   name = "github.com/gogo/protobuf"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/confio/weave"
-  branch = "master"
+  branch = "alpes-permission-review"
 
 [[constraint]]
   name = "github.com/gogo/protobuf"

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -29,35 +29,32 @@ func TestApp(t *testing.T) {
 	// let's set up a genesis file with some cash
 	pk := crypto.GenPrivKeyEd25519()
 	addr := pk.PublicKey().Address()
-	genesis := fmt.Sprintf(`{
-        "chain_id": "%s",
-        "app_state": {
-            "wallets": [{
-                "name": "demote",
-                "address": "%s",
-                "coins": [{
-                    "whole": 50000,
-                    "ticker": "ETH"
-                    }, {
-                    "whole": 1234,
-                    "ticker": "FRNK"
-                }]
-            }],
-            "tokens": [{
-                "ticker": "ETH",
-                "name": "Smells like ethereum",
-                "sig_figs": 9
-            },{
-                "ticker": "FRNK",
-                "name": "Frankie",
-                "sig_figs": 3
+	appState := fmt.Sprintf(`{
+        "wallets": [{
+            "name": "demote",
+            "address": "%s",
+            "coins": [{
+                "whole": 50000,
+                "ticker": "ETH"
+                }, {
+                "whole": 1234,
+                "ticker": "FRNK"
             }]
-        }
-    }`, chainID, addr)
+        }],
+        "tokens": [{
+            "ticker": "ETH",
+            "name": "Smells like ethereum",
+            "sig_figs": 9
+        },{
+            "ticker": "FRNK",
+            "name": "Frankie",
+            "sig_figs": 3
+        }]
+    }`, addr)
 
 	// Commit first block, make sure non-nil hash
-	myApp.InitChainWithGenesis(abci.RequestInitChain{}, []byte(genesis))
-	header := abci.Header{Height: 1}
+	myApp.InitChain(abci.RequestInitChain{AppStateBytes: []byte(appState)})
+	header := abci.Header{Height: 1, ChainID: chainID}
 	myApp.BeginBlock(abci.RequestBeginBlock{Header: header})
 	myApp.EndBlock(abci.RequestEndBlock{})
 	cres := myApp.Commit()

--- a/app/init.go
+++ b/app/init.go
@@ -79,10 +79,6 @@ func GenerateApp(home string, logger log.Logger) (abci.Application, error) {
 	}
 	app.WithInit(namecoin.Initializer{})
 
-	// guess the location of the genesis file
-	genesisPath := filepath.Join(home, "config", "genesis.json")
-	app.WithGenesis(genesisPath)
-
 	// set the logger and return
 	app.WithLogger(logger)
 	return app, nil

--- a/x/escrow/codec.pb.go
+++ b/x/escrow/codec.pb.go
@@ -42,7 +42,7 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 // Note that if the arbiter is a Hashlock permission, we have
 // an HTLC ;)
 type Escrow struct {
-	// Sender, Arbiter, Recipient are all weave.Permission
+	// Sender, Arbiter, Recipient are all weave.Condition
 	Sender    []byte `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty"`
 	Arbiter   []byte `protobuf:"bytes,2,opt,name=arbiter,proto3" json:"arbiter,omitempty"`
 	Recipient []byte `protobuf:"bytes,3,opt,name=recipient,proto3" json:"recipient,omitempty"`
@@ -105,7 +105,7 @@ func (m *Escrow) GetMemo() string {
 // If sender is not defined, it defaults to the first signer
 // The rest must be defined
 type CreateEscrowMsg struct {
-	// Sender, Arbiter, Recipient are all weave.Permission
+	// Sender, Arbiter, Recipient are all weave.Condition
 	Sender    []byte `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty"`
 	Arbiter   []byte `protobuf:"bytes,2,opt,name=arbiter,proto3" json:"arbiter,omitempty"`
 	Recipient []byte `protobuf:"bytes,3,opt,name=recipient,proto3" json:"recipient,omitempty"`

--- a/x/escrow/codec.proto
+++ b/x/escrow/codec.proto
@@ -19,6 +19,7 @@ message Escrow {
     // amount may contain multiple token types
     repeated x.Coin amount = 4;
     // if unreleased before timeout, will return to sender
+    // timeout stored here is absolute block height
     int64 timeout = 5;
     // max length 128 character
     string memo = 6;

--- a/x/escrow/errors.go
+++ b/x/escrow/errors.go
@@ -11,8 +11,8 @@ import (
 // escrow takes 1010-1020
 const (
 	CodeNoEscrow          = 1010
-	CodeMissingPermission = 1011
-	CodeInvalidPermission = 1012
+	CodeMissingCondition = 1011
+	CodeInvalidCondition = 1012
 	CodeInvalidMetadata   = 1013
 	CodeInvalidHeight     = 1014
 
@@ -24,7 +24,7 @@ var (
 	errMissingArbiter        = fmt.Errorf("Missing Arbiter")
 	errMissingSender         = fmt.Errorf("Missing Sender")
 	errMissingRecipient      = fmt.Errorf("Missing Recipient")
-	errMissingAllPermissions = fmt.Errorf("Missing All Permissions")
+	errMissingAllConditions = fmt.Errorf("Missing All Conditions")
 
 	errInvalidMemo     = fmt.Errorf("Memo field too long")
 	errInvalidTimeout  = fmt.Errorf("Invalid Timeout")
@@ -42,26 +42,26 @@ var (
 )
 
 func ErrMissingArbiter() error {
-	return errors.WithCode(errMissingArbiter, CodeMissingPermission)
+	return errors.WithCode(errMissingArbiter, CodeMissingCondition)
 }
 func ErrMissingSender() error {
-	return errors.WithCode(errMissingSender, CodeMissingPermission)
+	return errors.WithCode(errMissingSender, CodeMissingCondition)
 }
 func ErrMissingRecipient() error {
-	return errors.WithCode(errMissingRecipient, CodeMissingPermission)
+	return errors.WithCode(errMissingRecipient, CodeMissingCondition)
 }
-func ErrMissingAllPermissions() error {
-	return errors.WithCode(errMissingAllPermissions, CodeMissingPermission)
+func ErrMissingAllConditions() error {
+	return errors.WithCode(errMissingAllConditions, CodeMissingCondition)
 }
-func IsMissingPermissionErr(err error) bool {
-	return errors.HasErrorCode(err, CodeMissingPermission)
+func IsMissingConditionErr(err error) bool {
+	return errors.HasErrorCode(err, CodeMissingCondition)
 }
 
-func ErrInvalidPermission(perm []byte) error {
-	return errors.ErrUnrecognizedPermission(perm)
+func ErrInvalidCondition(perm []byte) error {
+	return errors.ErrUnrecognizedCondition(perm)
 }
-func IsInvalidPermissionErr(err error) bool {
-	return errors.IsUnrecognizedPermissionErr(err)
+func IsInvalidConditionErr(err error) bool {
+	return errors.IsUnrecognizedConditionErr(err)
 }
 
 func ErrInvalidMemo(memo string) error {

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -28,7 +28,7 @@ func RegisterRoutes(r weave.Registry, auth x.Authenticator,
 	r.Handle(pathUpdateEscrowPartiesMsg, UpdateEscrowHandler{auth, bucket})
 }
 
-// RegisterQuery will register this bucket as "/wallets"
+// RegisterQuery will register this bucket as "/escrows"
 func RegisterQuery(qr weave.QueryRouter) {
 	NewBucket().Register("escrows", qr)
 }
@@ -173,11 +173,10 @@ func (h ReleaseEscrowHandler) Check(ctx weave.Context, db weave.KVStore,
 func (h ReleaseEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	tx weave.Tx) (weave.DeliverResult, error) {
 	var res weave.DeliverResult
-	msg, obj, err := h.validate(ctx, db, tx)
+	msg, escrow, err := h.validate(ctx, db, tx)
 	if err != nil {
 		return res, err
 	}
-	escrow := AsEscrow(obj)
 
 	// use amount in message, or
 	request := x.Coins(msg.Amount)
@@ -192,7 +191,8 @@ func (h ReleaseEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	}
 
 	// move the money from escrow to recipient
-	sender := Condition(obj.Key()).Address()
+	key := msg.EscrowId
+	sender := Condition(key).Address()
 	dest := weave.Condition(escrow.Recipient).Address()
 	for _, c := range request {
 		err := h.cash.MoveCoins(db, sender, dest, *c)
@@ -210,13 +210,14 @@ func (h ReleaseEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	// if there is something left, just update the balance...
 	if available.IsPositive() {
 		// return id as we can use again
-		res.Data = obj.Key()
+		res.Data = key
 		// this updates the object, as we have a pointer
 		escrow.Amount = available
+		obj := orm.NewSimpleObj(key, escrow)
 		err = h.bucket.Save(db, obj)
 	} else {
 		// otherwise we finished the escrow and can delete it
-		err = h.bucket.Delete(db, obj.Key())
+		err = h.bucket.Delete(db, key)
 	}
 
 	// returns error if Save/Delete failed
@@ -225,7 +226,7 @@ func (h ReleaseEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 
 // validate does all common pre-processing between Check and Deliver
 func (h ReleaseEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
-	tx weave.Tx) (*ReleaseEscrowMsg, orm.Object, error) {
+	tx weave.Tx) (*ReleaseEscrowMsg, *Escrow, error) {
 
 	rmsg, err := tx.GetMsg()
 	if err != nil {
@@ -241,14 +242,9 @@ func (h ReleaseEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 		return nil, nil, err
 	}
 
-	// load escrow
-	obj, err := h.bucket.Get(db, msg.EscrowId)
+	escrow, err := loadEscrow(h.bucket, db, msg.EscrowId)
 	if err != nil {
 		return nil, nil, err
-	}
-	escrow := AsEscrow(obj)
-	if escrow == nil {
-		return nil, nil, ErrNoSuchEscrow(msg.EscrowId)
 	}
 
 	// arbiter must authorize this
@@ -263,7 +259,7 @@ func (h ReleaseEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 		return nil, nil, ErrEscrowExpired(escrow.Timeout)
 	}
 
-	return msg, obj, nil
+	return msg, escrow, nil
 }
 
 //---- return
@@ -282,7 +278,7 @@ var _ weave.Handler = ReturnEscrowHandler{}
 func (h ReturnEscrowHandler) Check(ctx weave.Context, db weave.KVStore,
 	tx weave.Tx) (weave.CheckResult, error) {
 	var res weave.CheckResult
-	_, err := h.validate(ctx, db, tx)
+	_, _, err := h.validate(ctx, db, tx)
 	if err != nil {
 		return res, err
 	}
@@ -297,14 +293,13 @@ func (h ReturnEscrowHandler) Check(ctx weave.Context, db weave.KVStore,
 func (h ReturnEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	tx weave.Tx) (weave.DeliverResult, error) {
 	var res weave.DeliverResult
-	obj, err := h.validate(ctx, db, tx)
+	key, escrow, err := h.validate(ctx, db, tx)
 	if err != nil {
 		return res, err
 	}
-	escrow := AsEscrow(obj)
 
 	// move the money from escrow to recipient
-	sender := Condition(obj.Key()).Address()
+	sender := Condition(key).Address()
 	dest := weave.Condition(escrow.Sender).Address()
 	for _, c := range escrow.Amount {
 		err := h.cash.MoveCoins(db, sender, dest, *c)
@@ -315,7 +310,7 @@ func (h ReturnEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	}
 
 	// now remove the finished escrow
-	err = h.bucket.Delete(db, obj.Key())
+	err = h.bucket.Delete(db, key)
 
 	// returns error if Delete failed
 	return res, err
@@ -323,39 +318,40 @@ func (h ReturnEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 
 // validate does all common pre-processing between Check and Deliver
 func (h ReturnEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
-	tx weave.Tx) (orm.Object, error) {
+	tx weave.Tx) ([]byte, *Escrow, error) {
 
 	rmsg, err := tx.GetMsg()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	msg, ok := rmsg.(*ReturnEscrowMsg)
 	if !ok {
-		return nil, errors.ErrUnknownTxType(rmsg)
+		return nil, nil, errors.ErrUnknownTxType(rmsg)
 	}
 
 	err = msg.Validate()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// load escrow
-	obj, err := h.bucket.Get(db, msg.EscrowId)
+	key := msg.EscrowId
+	obj, err := h.bucket.Get(db, key)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	escrow := AsEscrow(obj)
 	if escrow == nil {
-		return nil, ErrNoSuchEscrow(msg.EscrowId)
+		return nil, nil, ErrNoSuchEscrow(key)
 	}
 
 	// timeout must have expired
 	height, _ := weave.GetHeight(ctx)
 	if height <= escrow.Timeout {
-		return nil, ErrEscrowNotExpired(escrow.Timeout)
+		return nil, nil, ErrEscrowNotExpired(escrow.Timeout)
 	}
 
-	return obj, nil
+	return key, escrow, nil
 }
 
 //---- update
@@ -388,11 +384,10 @@ func (h UpdateEscrowHandler) Check(ctx weave.Context, db weave.KVStore,
 func (h UpdateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	tx weave.Tx) (weave.DeliverResult, error) {
 	var res weave.DeliverResult
-	msg, obj, err := h.validate(ctx, db, tx)
+	msg, escrow, err := h.validate(ctx, db, tx)
 	if err != nil {
 		return res, err
 	}
-	escrow := AsEscrow(obj)
 
 	// update the escrow with message values
 	if msg.Sender != nil {
@@ -406,6 +401,8 @@ func (h UpdateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	}
 
 	// save the updated escrow
+	key := msg.EscrowId
+	obj := orm.NewSimpleObj(key, escrow)
 	err = h.bucket.Save(db, obj)
 
 	// returns error if Save failed
@@ -414,7 +411,7 @@ func (h UpdateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 
 // validate does all common pre-processing between Check and Deliver
 func (h UpdateEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
-	tx weave.Tx) (*UpdateEscrowPartiesMsg, orm.Object, error) {
+	tx weave.Tx) (*UpdateEscrowPartiesMsg, *Escrow, error) {
 
 	rmsg, err := tx.GetMsg()
 	if err != nil {
@@ -466,5 +463,20 @@ func (h UpdateEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 		}
 	}
 
-	return msg, obj, nil
+	return msg, escrow, nil
+}
+
+// helpers
+
+// load escrow and cast it, returns error if not present
+func loadEscrow(bucket Bucket, db weave.KVStore, escrowID []byte) (*Escrow, error) {
+	obj, err := bucket.Get(db, escrowID)
+	if err != nil {
+		return nil, err
+	}
+	escrow := AsEscrow(obj)
+	if escrow == nil {
+		return nil, ErrNoSuchEscrow(escrowID)
+	}
+	return escrow, nil
 }

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -70,7 +70,7 @@ func (h CreateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	}
 
 	// apply a default for sender
-	sender := weave.Permission(msg.Sender)
+	sender := weave.Condition(msg.Sender)
 	if sender == nil {
 		sender = x.MainSigner(ctx, h.auth)
 	}
@@ -90,7 +90,7 @@ func (h CreateEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	}
 
 	// move the money to this object
-	dest := Permission(obj.Key()).Address()
+	dest := Condition(obj.Key()).Address()
 	sendAddr := sender.Address()
 	for _, c := range escrow.Amount {
 		err := h.cash.MoveCoins(db, sendAddr, dest, *c)
@@ -131,7 +131,7 @@ func (h CreateEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 
 	// sender must authorize this (if not set, defaults to MainSigner)
 	if msg.Sender != nil {
-		sender := weave.Permission(msg.Sender).Address()
+		sender := weave.Condition(msg.Sender).Address()
 		if !h.auth.HasAddress(ctx, sender) {
 			return nil, errors.ErrUnauthorized()
 		}
@@ -192,8 +192,8 @@ func (h ReleaseEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	}
 
 	// move the money from escrow to recipient
-	sender := Permission(obj.Key()).Address()
-	dest := weave.Permission(escrow.Recipient).Address()
+	sender := Condition(obj.Key()).Address()
+	dest := weave.Condition(escrow.Recipient).Address()
 	for _, c := range request {
 		err := h.cash.MoveCoins(db, sender, dest, *c)
 		if err != nil {
@@ -252,7 +252,7 @@ func (h ReleaseEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 	}
 
 	// arbiter must authorize this
-	arbiter := weave.Permission(escrow.Arbiter).Address()
+	arbiter := weave.Condition(escrow.Arbiter).Address()
 	if !h.auth.HasAddress(ctx, arbiter) {
 		return nil, nil, errors.ErrUnauthorized()
 	}
@@ -304,8 +304,8 @@ func (h ReturnEscrowHandler) Deliver(ctx weave.Context, db weave.KVStore,
 	escrow := AsEscrow(obj)
 
 	// move the money from escrow to recipient
-	sender := Permission(obj.Key()).Address()
-	dest := weave.Permission(escrow.Sender).Address()
+	sender := Condition(obj.Key()).Address()
+	dest := weave.Condition(escrow.Sender).Address()
 	for _, c := range escrow.Amount {
 		err := h.cash.MoveCoins(db, sender, dest, *c)
 		if err != nil {
@@ -448,19 +448,19 @@ func (h UpdateEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 
 	// we must have the permission for the items we want to change
 	if msg.Sender != nil {
-		sender := weave.Permission(escrow.Sender).Address()
+		sender := weave.Condition(escrow.Sender).Address()
 		if !h.auth.HasAddress(ctx, sender) {
 			return nil, nil, errors.ErrUnauthorized()
 		}
 	}
 	if msg.Recipient != nil {
-		rcpt := weave.Permission(escrow.Recipient).Address()
+		rcpt := weave.Condition(escrow.Recipient).Address()
 		if !h.auth.HasAddress(ctx, rcpt) {
 			return nil, nil, errors.ErrUnauthorized()
 		}
 	}
 	if msg.Arbiter != nil {
-		arbiter := weave.Permission(escrow.Arbiter).Address()
+		arbiter := weave.Condition(escrow.Arbiter).Address()
 		if !h.auth.HasAddress(ctx, arbiter) {
 			return nil, nil, errors.ErrUnauthorized()
 		}

--- a/x/escrow/handler.go
+++ b/x/escrow/handler.go
@@ -247,9 +247,9 @@ func (h ReleaseEscrowHandler) validate(ctx weave.Context, db weave.KVStore,
 		return nil, nil, err
 	}
 
-	// arbiter must authorize this
-	arbiter := weave.Condition(escrow.Arbiter).Address()
-	if !h.auth.HasAddress(ctx, arbiter) {
+	// arbiter or sender must authorize this
+	if !x.HasNConditions(ctx, h.auth,
+		[]weave.Condition{escrow.Arbiter, escrow.Sender}, 1) {
 		return nil, nil, errors.ErrUnauthorized()
 	}
 

--- a/x/escrow/handler_test.go
+++ b/x/escrow/handler_test.go
@@ -22,7 +22,7 @@ import (
 const authKey = "auth"
 
 type action struct {
-	perms  []weave.Permission
+	perms  []weave.Condition
 	msg    weave.Msg
 	height int64 // block height, for timeout
 }
@@ -35,7 +35,7 @@ func (a action) tx() weave.Tx {
 func (a action) ctx() weave.Context {
 	ctx := context.Background()
 	ctx = weave.WithHeight(ctx, a.height)
-	return authenticator().SetPermissions(ctx, a.perms...)
+	return authenticator().SetConditions(ctx, a.perms...)
 }
 
 // authenticator returns a default for all tests...
@@ -126,7 +126,7 @@ func TestHandler(t *testing.T) {
 		return bz
 	}
 	eaddr := func(i int64) weave.Address {
-		return Permission(id(i)).Address()
+		return Condition(id(i)).Address()
 	}
 
 	cases := []struct {
@@ -148,7 +148,7 @@ func TestHandler(t *testing.T) {
 			all,
 			nil, // no prep, just one action
 			action{
-				perms:  []weave.Permission{a},
+				perms:  []weave.Condition{a},
 				msg:    NewCreateMsg(a, b, c, all, 12345, ""),
 				height: 1000,
 			},
@@ -184,7 +184,7 @@ func TestHandler(t *testing.T) {
 			all,
 			nil, // no prep, just one action
 			action{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				// defaults to sender!
 				msg:    NewCreateMsg(nil, b, c, some, 777, ""),
 				height: 123,
@@ -253,7 +253,7 @@ func TestHandler(t *testing.T) {
 			some,
 			nil, // no prep, just one action
 			action{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				// defaults to sender!
 				msg:    NewCreateMsg(nil, b, c, all, 12345, ""),
 				height: 123,
@@ -267,7 +267,7 @@ func TestHandler(t *testing.T) {
 			all,
 			nil, // no prep, just one action
 			action{
-				perms:  []weave.Permission{b},
+				perms:  []weave.Condition{b},
 				msg:    NewCreateMsg(a, b, c, some, 12345, ""),
 				height: 123,
 			},
@@ -280,7 +280,7 @@ func TestHandler(t *testing.T) {
 			all,
 			nil, // no prep, just one action
 			action{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				// defaults to sender!
 				msg:    NewCreateMsg(nil, b, c, all, 123, ""),
 				height: 888,
@@ -293,12 +293,12 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms:  []weave.Permission{a},
+				perms:  []weave.Condition{a},
 				msg:    NewCreateMsg(a, b, c, all, 12345, ""),
 				height: 1000,
 			}},
 			action{
-				perms: []weave.Permission{b},
+				perms: []weave.Condition{b},
 				msg: &ReleaseEscrowMsg{
 					EscrowId: id(1),
 				},
@@ -312,12 +312,12 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms:  []weave.Permission{a},
+				perms:  []weave.Condition{a},
 				msg:    NewCreateMsg(a, b, c, all, 12345, ""),
 				height: 1000,
 			}},
 			action{
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				msg: &ReleaseEscrowMsg{
 					EscrowId: id(1),
 				},
@@ -357,12 +357,12 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms:  []weave.Permission{a},
+				perms:  []weave.Condition{a},
 				msg:    NewCreateMsg(a, b, c, all, 12345, "hello"),
 				height: 1000,
 			}},
 			action{
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				msg: &ReleaseEscrowMsg{
 					EscrowId: id(1),
 					Amount:   some,
@@ -407,12 +407,12 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms:  []weave.Permission{a},
+				perms:  []weave.Condition{a},
 				msg:    NewCreateMsg(a, b, c, all, 1234, ""),
 				height: 1000,
 			}},
 			action{
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				msg: &ReleaseEscrowMsg{
 					EscrowId: id(1),
 				},
@@ -426,12 +426,12 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms:  []weave.Permission{a},
+				perms:  []weave.Condition{a},
 				msg:    NewCreateMsg(a, b, c, some, 12345, ""),
 				height: 1000,
 			}},
 			action{
-				perms: []weave.Permission{d},
+				perms: []weave.Condition{d},
 				msg: &ReturnEscrowMsg{
 					EscrowId: id(1),
 				},
@@ -464,12 +464,12 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms:  []weave.Permission{a},
+				perms:  []weave.Condition{a},
 				msg:    NewCreateMsg(a, b, c, all, 1234, ""),
 				height: 1000,
 			}},
 			action{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				msg: &ReturnEscrowMsg{
 					EscrowId: id(1),
 				},
@@ -484,12 +484,12 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				// defaults to sender!
 				msg:    NewCreateMsg(a, b, c, some, 12345, ""),
 				height: 123,
 			}, {
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				// c hands off to d
 				msg: &UpdateEscrowPartiesMsg{
 					EscrowId: id(1),
@@ -499,7 +499,7 @@ func TestHandler(t *testing.T) {
 			}},
 			action{
 				// new arbiter can resolve
-				perms: []weave.Permission{d},
+				perms: []weave.Condition{d},
 				msg: &ReleaseEscrowMsg{
 					EscrowId: id(1),
 				},
@@ -532,12 +532,12 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				// defaults to sender!
 				msg:    NewCreateMsg(a, b, c, some, 12345, ""),
 				height: 123,
 			}, {
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				// c hands off to d
 				msg: &UpdateEscrowPartiesMsg{
 					EscrowId: id(1),
@@ -547,7 +547,7 @@ func TestHandler(t *testing.T) {
 			}},
 			action{
 				// original arbiter can no longer resolve
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				msg: &ReleaseEscrowMsg{
 					EscrowId: id(1),
 				},
@@ -561,13 +561,13 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				// defaults to sender!
 				msg:    NewCreateMsg(a, b, c, some, 12345, ""),
 				height: 123,
 			}},
 			action{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				msg: &UpdateEscrowPartiesMsg{
 					EscrowId: id(1),
 					Arbiter:  a,
@@ -582,13 +582,13 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms: []weave.Permission{a},
+				perms: []weave.Condition{a},
 				// defaults to sender!
 				msg:    NewCreateMsg(a, b, c, some, 12345, ""),
 				height: 123,
 			}},
 			action{
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				msg: &UpdateEscrowPartiesMsg{
 					EscrowId: id(1),
 					Arbiter:  d,
@@ -603,18 +603,18 @@ func TestHandler(t *testing.T) {
 			a.Address(),
 			all,
 			[]action{{
-				perms:  []weave.Permission{a},
+				perms:  []weave.Condition{a},
 				msg:    NewCreateMsg(a, b, c, all, 12345, ""),
 				height: 1000,
 			}, {
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				msg: &ReleaseEscrowMsg{
 					EscrowId: id(1),
 				},
 				height: 2000,
 			}},
 			action{
-				perms: []weave.Permission{c},
+				perms: []weave.Condition{c},
 				msg: &ReleaseEscrowMsg{
 					EscrowId: id(1),
 				},
@@ -747,7 +747,7 @@ func TestAtomicSwap(t *testing.T) {
 		// amount we wish to swap
 		aSwap, bSwap x.Coins
 		// arbiter, same on both
-		arbiter weave.Permission
+		arbiter weave.Condition
 		// preimage used in claim
 		preimage []byte
 		// does the release cause an error?
@@ -758,7 +758,7 @@ func TestAtomicSwap(t *testing.T) {
 		0: {
 			foo, bar,
 			lilFoo, lilBar,
-			hashlock.PreimagePermission([]byte{1, 2, 3}),
+			hashlock.PreimageCondition([]byte{1, 2, 3}),
 			[]byte("foo"),
 			true,
 			// money stayed in escrow
@@ -769,7 +769,7 @@ func TestAtomicSwap(t *testing.T) {
 		1: {
 			foo, bar,
 			lilFoo, lilBar,
-			hashlock.PreimagePermission([]byte{7, 8, 9}),
+			hashlock.PreimageCondition([]byte{7, 8, 9}),
 			[]byte{7, 8, 9},
 			false,
 			// the coins were properly released
@@ -796,7 +796,7 @@ func TestAtomicSwap(t *testing.T) {
 
 	// use both context auth and hashlock auth
 	auth := x.ChainAuth(authenticator(), hashlock.Authenticate{})
-	setAuth := authenticator().SetPermissions
+	setAuth := authenticator().SetConditions
 
 	// route the escrow commands, and wrap with the hashlock
 	// middleware

--- a/x/escrow/model.go
+++ b/x/escrow/model.go
@@ -39,7 +39,7 @@ func (e *Escrow) Validate() error {
 	if err := validateAmount(e.Amount); err != nil {
 		return err
 	}
-	return validatePermissions(e.Arbiter, e.Sender, e.Recipient)
+	return validateConditions(e.Arbiter, e.Sender, e.Recipient)
 }
 
 // Copy makes a new set with the same coins
@@ -63,7 +63,7 @@ func AsEscrow(obj orm.Object) *Escrow {
 }
 
 // NewEscrow creates an escrow orm.Object
-func NewEscrow(id []byte, sender, rcpt, arb weave.Permission,
+func NewEscrow(id []byte, sender, rcpt, arb weave.Condition,
 	amount x.Coins, timeout int64, memo string) orm.Object {
 	esc := &Escrow{
 		Sender:    sender,
@@ -76,10 +76,10 @@ func NewEscrow(id []byte, sender, rcpt, arb weave.Permission,
 	return orm.NewSimpleObj(id, esc)
 }
 
-// Permission calculates the address of an escrow given
+// Condition calculates the address of an escrow given
 // the key
-func Permission(key []byte) weave.Permission {
-	return weave.NewPermission("escrow", "seq", key)
+func Condition(key []byte) weave.Condition {
+	return weave.NewCondition("escrow", "seq", key)
 }
 
 // NewEscrow generates a new Escrow object

--- a/x/escrow/model.go
+++ b/x/escrow/model.go
@@ -54,7 +54,9 @@ func (e *Escrow) Copy() orm.CloneableData {
 	}
 }
 
-// AsEscrow safely extracts a Escrow value from the object
+// AsEscrow extracts an *Escrow value or nil from the object
+// Must be called on a Bucket result that is an *Escrow,
+// will panic on bad type.
 func AsEscrow(obj orm.Object) *Escrow {
 	if obj == nil || obj.Value() == nil {
 		return nil

--- a/x/escrow/msg.go
+++ b/x/escrow/msg.go
@@ -45,7 +45,7 @@ func (UpdateEscrowPartiesMsg) Path() string {
 //--------- Validation --------
 
 // NewCreateMsg is a helper to quickly build a create escrow message
-func NewCreateMsg(send, rcpt, arb weave.Permission,
+func NewCreateMsg(send, rcpt, arb weave.Condition,
 	amount x.Coins, timeout int64, memo string) *CreateEscrowMsg {
 	return &CreateEscrowMsg{
 		Sender:    send,
@@ -74,7 +74,7 @@ func (m *CreateEscrowMsg) Validate() error {
 	if err := validateAmount(m.Amount); err != nil {
 		return err
 	}
-	return validatePermissions(m.Arbiter, m.Sender, m.Recipient)
+	return validateConditions(m.Arbiter, m.Sender, m.Recipient)
 }
 
 // Validate makes sure that this is sensible
@@ -104,14 +104,14 @@ func (m *UpdateEscrowPartiesMsg) Validate() error {
 	if m.Arbiter == nil &&
 		m.Sender == nil &&
 		m.Recipient == nil {
-		return ErrMissingAllPermissions()
+		return ErrMissingAllConditions()
 	}
-	return validatePermissions(m.Arbiter, m.Sender, m.Recipient)
+	return validateConditions(m.Arbiter, m.Sender, m.Recipient)
 }
 
-// validatePermissions returns an error if any permission doesn't validate
+// validateConditions returns an error if any permission doesn't validate
 // nil is considered valid here
-func validatePermissions(perms ...weave.Permission) error {
+func validateConditions(perms ...weave.Condition) error {
 	for _, p := range perms {
 		if p != nil {
 			if err := p.Validate(); err != nil {

--- a/x/escrow/msg_test.go
+++ b/x/escrow/msg_test.go
@@ -30,9 +30,9 @@ func TestCreateEscrowMsg(t *testing.T) {
 	// good
 	_, a := helpers.MakeKey()
 	_, b := helpers.MakeKey()
-	c := weave.NewPermission("monkey", "gelato", []byte("berry"))
+	c := weave.NewCondition("monkey", "gelato", []byte("berry"))
 	// invalid
-	d := weave.Permission("foobar")
+	d := weave.Condition("foobar")
 
 	// good
 	plus := mustCombineCoins(x.NewCoin(100, 0, "FOO"))
@@ -46,7 +46,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 		check checkErr
 	}{
 		// nothing
-		0: {new(CreateEscrowMsg), IsMissingPermissionErr},
+		0: {new(CreateEscrowMsg), IsMissingConditionErr},
 		// proper
 		1: {
 			&CreateEscrowMsg{
@@ -77,7 +77,7 @@ func TestCreateEscrowMsg(t *testing.T) {
 				Amount:    plus,
 				Timeout:   52,
 			},
-			IsInvalidPermissionErr,
+			IsInvalidConditionErr,
 		},
 		// negative amount
 		4: {
@@ -263,9 +263,9 @@ func TestUpdateEscrowMsg(t *testing.T) {
 	// good
 	_, a := helpers.MakeKey()
 	_, b := helpers.MakeKey()
-	c := weave.NewPermission("monkey", "gelato", []byte("berry"))
+	c := weave.NewCondition("monkey", "gelato", []byte("berry"))
 	// invalid
-	d := weave.Permission("foobar")
+	d := weave.Condition("foobar")
 
 	cases := []struct {
 		msg   *UpdateEscrowPartiesMsg
@@ -286,7 +286,7 @@ func TestUpdateEscrowMsg(t *testing.T) {
 			&UpdateEscrowPartiesMsg{
 				EscrowId: escrow,
 			},
-			IsMissingPermissionErr,
+			IsMissingConditionErr,
 		},
 		// invalid escrow, proper permissions
 		3: {
@@ -311,7 +311,7 @@ func TestUpdateEscrowMsg(t *testing.T) {
 				EscrowId: escrow,
 				Arbiter:  d,
 			},
-			IsInvalidPermissionErr,
+			IsInvalidConditionErr,
 		},
 	}
 

--- a/x/hashlock/context.go
+++ b/x/hashlock/context.go
@@ -20,7 +20,7 @@ const (
 // can add a signer
 func withPreimage(ctx weave.Context, preimage []byte) weave.Context {
 	return context.WithValue(ctx, contextKeyPreimage,
-		PreimagePermission(preimage))
+		PreimageCondition(preimage))
 }
 
 // Authenticate implements x.Authenticator and provides
@@ -29,21 +29,21 @@ type Authenticate struct{}
 
 var _ x.Authenticator = Authenticate{}
 
-// GetPermissions returns which preimages have authorized the current Context.
+// GetConditions returns which preimages have authorized the current Context.
 // May be nil
-func (a Authenticate) GetPermissions(ctx weave.Context) []weave.Permission {
+func (a Authenticate) GetConditions(ctx weave.Context) []weave.Condition {
 	// (val, ok) form to return nil instead of panic if unset
-	val, _ := ctx.Value(contextKeyPreimage).(weave.Permission)
+	val, _ := ctx.Value(contextKeyPreimage).(weave.Condition)
 	if val == nil {
 		return nil
 	}
-	return []weave.Permission{val}
+	return []weave.Condition{val}
 }
 
 // HasAddress returns true if the given address
 // had the preimage permission in the current Context.
 func (a Authenticate) HasAddress(ctx weave.Context, addr weave.Address) bool {
-	val, _ := ctx.Value(contextKeyPreimage).(weave.Permission)
+	val, _ := ctx.Value(contextKeyPreimage).(weave.Condition)
 	if val != nil && val.Address().Equals(addr) {
 		return true
 	}

--- a/x/hashlock/context_test.go
+++ b/x/hashlock/context_test.go
@@ -12,28 +12,28 @@ import (
 func TestContext(t *testing.T) {
 	// sig is a signature permission, not a hash
 	foo := []byte("foo")
-	sig := weave.NewPermission("sigs", "ed25519", foo).Address()
+	sig := weave.NewCondition("sigs", "ed25519", foo).Address()
 	// other is a permission for some "other" preimage
-	other := PreimagePermission(foo).Address()
+	other := PreimageCondition(foo).Address()
 	random := weave.NewAddress(foo)
 
 	bg := context.Background()
 	cases := []struct {
 		ctx   weave.Context
-		perms []weave.Permission
+		perms []weave.Condition
 		match []weave.Address
 		not   []weave.Address
 	}{
 		{bg, nil, nil, []weave.Address{sig, other, random}},
 		{
 			withPreimage(bg, foo),
-			[]weave.Permission{PreimagePermission(foo)},
+			[]weave.Condition{PreimageCondition(foo)},
 			[]weave.Address{other},
 			[]weave.Address{sig, random},
 		},
 		{
 			withPreimage(bg, []byte("one more time")),
-			[]weave.Permission{PreimagePermission([]byte("one more time"))},
+			[]weave.Condition{PreimageCondition([]byte("one more time"))},
 			nil,
 			[]weave.Address{sig, other, random},
 		},
@@ -43,7 +43,7 @@ func TestContext(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-			perms := auth.GetPermissions(tc.ctx)
+			perms := auth.GetConditions(tc.ctx)
 			assert.Equal(t, tc.perms, perms)
 
 			for _, a := range tc.match {

--- a/x/hashlock/decorator_test.go
+++ b/x/hashlock/decorator_test.go
@@ -30,7 +30,7 @@ func TestDecorator(t *testing.T) {
 
 	cases := []struct {
 		tx    weave.Tx
-		perms []weave.Permission
+		perms []weave.Condition
 	}{
 		// doesn't support hashlock interface
 		{helpers.MockTx(helpers.MockMsg([]byte{1, 2, 3})), nil},
@@ -38,7 +38,7 @@ func TestDecorator(t *testing.T) {
 		{hashTx([]byte("john"), nil), nil},
 		// Hash a preimage
 		{hashTx([]byte("foo"), []byte("bar")),
-			[]weave.Permission{PreimagePermission([]byte("bar"))}},
+			[]weave.Condition{PreimageCondition([]byte("bar"))}},
 	}
 
 	for i, tc := range cases {
@@ -58,20 +58,20 @@ func TestDecorator(t *testing.T) {
 
 // HashCheckHandler stores the seen permissions on each call
 type HashCheckHandler struct {
-	Perms []weave.Permission
+	Perms []weave.Condition
 }
 
 var _ weave.Handler = (*HashCheckHandler)(nil)
 
 func (s *HashCheckHandler) Check(ctx weave.Context, store weave.KVStore,
 	tx weave.Tx) (res weave.CheckResult, err error) {
-	s.Perms = Authenticate{}.GetPermissions(ctx)
+	s.Perms = Authenticate{}.GetConditions(ctx)
 	return
 }
 
 func (s *HashCheckHandler) Deliver(ctx weave.Context, store weave.KVStore,
 	tx weave.Tx) (res weave.DeliverResult, err error) {
-	s.Perms = Authenticate{}.GetPermissions(ctx)
+	s.Perms = Authenticate{}.GetConditions(ctx)
 	return
 }
 

--- a/x/hashlock/tx.go
+++ b/x/hashlock/tx.go
@@ -14,8 +14,8 @@ type HashKeyTx interface {
 	GetPreimage() []byte
 }
 
-// PreimagePermission calculates a sha256 hash and then
-func PreimagePermission(preimage []byte) weave.Permission {
+// PreimageCondition calculates a sha256 hash and then
+func PreimageCondition(preimage []byte) weave.Condition {
 	h := sha256.Sum256(preimage)
-	return weave.NewPermission("hash", "sha256", h[:])
+	return weave.NewCondition("hash", "sha256", h[:])
 }

--- a/x/namecoin/handler_test.go
+++ b/x/namecoin/handler_test.go
@@ -34,13 +34,13 @@ func TestSendHandler(t *testing.T) {
 	foo := x.NewCoin(100, 0, "FOO")
 	some := x.NewCoin(300, 0, "SOME")
 
-	perm := weave.NewPermission("sig", "ed25519", []byte{1, 2, 3})
-	perm2 := weave.NewPermission("sig", "ed25519", []byte{4, 5, 6})
+	perm := weave.NewCondition("sig", "ed25519", []byte{1, 2, 3})
+	perm2 := weave.NewCondition("sig", "ed25519", []byte{4, 5, 6})
 	addr := perm.Address()
 	addr2 := perm2.Address()
 
 	cases := []struct {
-		signers       []weave.Permission
+		signers       []weave.Condition
 		initState     []orm.Object
 		msg           weave.Msg
 		expectCheck   checkErr
@@ -58,7 +58,7 @@ func TestSendHandler(t *testing.T) {
 		},
 		// sender has no account
 		4: {
-			[]weave.Permission{perm},
+			[]weave.Condition{perm},
 			nil,
 			&cash.SendMsg{Amount: &foo, Src: addr, Dest: addr2},
 			noErr, // we don't check funds
@@ -66,7 +66,7 @@ func TestSendHandler(t *testing.T) {
 		},
 		// sender too poor
 		5: {
-			[]weave.Permission{perm},
+			[]weave.Condition{perm},
 			[]orm.Object{mo(WalletWith(addr, "", &some))},
 			&cash.SendMsg{Amount: &foo, Src: addr, Dest: addr2},
 			noErr, // we don't check funds
@@ -74,7 +74,7 @@ func TestSendHandler(t *testing.T) {
 		},
 		// fool and his money are soon parted....
 		6: {
-			[]weave.Permission{perm},
+			[]weave.Condition{perm},
 			[]orm.Object{mo(WalletWith(addr, "fool", &foo))},
 			&cash.SendMsg{Amount: &foo, Src: addr, Dest: addr2},
 			noErr,
@@ -120,7 +120,7 @@ func TestNewTokenHandler(t *testing.T) {
 
 	// TODO: add queries to verify
 	cases := []struct {
-		signers       []weave.Permission
+		signers       []weave.Condition
 		issuer        weave.Address
 		initState     []orm.Object
 		msg           weave.Msg
@@ -152,10 +152,10 @@ func TestNewTokenHandler(t *testing.T) {
 		// not enough permissions
 		7: {nil, addr, nil, msg,
 			errors.IsUnauthorizedErr, errors.IsUnauthorizedErr, "", nil},
-		8: {[]weave.Permission{perm2, perm3}, addr, nil, msg,
+		8: {[]weave.Condition{perm2, perm3}, addr, nil, msg,
 			errors.IsUnauthorizedErr, errors.IsUnauthorizedErr, "", nil},
 		// now have permission
-		9: {[]weave.Permission{perm2, perm3}, addr2, nil, msg,
+		9: {[]weave.Condition{perm2, perm3}, addr2, nil, msg,
 			noErr, noErr, ticker, added},
 	}
 
@@ -207,7 +207,7 @@ func TestSetNameHandler(t *testing.T) {
 	dupUser := mo(WalletWith(addr2, name, &coin))
 
 	cases := []struct {
-		signer        weave.Permission
+		signer        weave.Condition
 		initState     []orm.Object
 		msg           weave.Msg
 		expectCheck   checkErr


### PR DESCRIPTION
These are a number of style and functionality cleanup based on Alex's code review of https://github.com/iov-one/bcp-demo/pull/3

Part of a two-repo cleanup, so it depends on https://github.com/confio/weave/pull/63 being reviewed and merged first.

Only big functionality change is that both sender and arbiter can now release an escrow to the recipient (not just arbiter)