### PR TITLE
initial upgrade to 0.19.9, TODO: lock weave when tagged

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,8 +34,8 @@
     "log/level",
     "log/term"
   ]
-  revision = "ca4112baa34cb55091301bdc13b1420a122b1b9e"
-  version = "v0.7.0"
+  revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
+  version = "v0.6.0"
 
 [[projects]]
   name = "github.com/go-logfmt/logfmt"
@@ -150,20 +150,23 @@
     "server",
     "types"
   ]
-  revision = "68592f4d8ee34e97db94b7a7976b1309efdb7eb9"
-  version = "v0.10.0"
+  revision = "78a8905690ef54f9d57e3b2b0ee7ad3a04ef3f1f"
+  version = "v0.10.3"
 
 [[projects]]
-  name = "github.com/tendermint/go-wire"
+  name = "github.com/tendermint/go-amino"
   packages = ["."]
-  revision = "fa721242b042ecd4c6ed1a934ee740db4f74e45c"
-  version = "v0.7.3"
+  revision = "3c22a7a539411f89a96738fcfa14c1027e24e5ec"
+  version = "0.9.10"
 
 [[projects]]
   name = "github.com/tendermint/iavl"
-  packages = ["."]
-  revision = "fd37a0fa3a7454423233bc3d5ea828f38e0af787"
-  version = "v0.7.0"
+  packages = [
+    ".",
+    "sha256truncated"
+  ]
+  revision = "c9206995e8f948e99927f5084a88a7e94ca256da"
+  version = "v0.8.0-rc0"
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"
@@ -172,16 +175,15 @@
     "db",
     "log"
   ]
-  revision = "1b9b5652a199ab0be2e781393fb275b66377309d"
-  version = "v0.7.0"
+  revision = "692f1d86a6e2c0efa698fd1e4541b68c74ffaf38"
+  version = "v0.8.4"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
-    "ed25519/internal/edwards25519",
-    "ripemd160"
+    "ed25519/internal/edwards25519"
   ]
   revision = "d6449816ce06963d9d136eee5a56fca5b0616e7e"
 
@@ -254,6 +256,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dfd363cd6543c20bc52f924559ceae313d2e7e5327b586e0b90c147f22d63ab2"
+  inputs-digest = "b25cd3f9e4b81e7f0c2a2a7eb43ac1d7dc766d43e3a99fca083d830a35ce4390"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,8 +18,8 @@
     "x/sigs",
     "x/utils"
   ]
-  revision = "ac1cf04ea790e0025eca432ae3ac36d1e5e42be4"
-  version = "v0.4.0"
+  revision = "9f4484ee27803d393aa2b16a0a649d307c588dbd"
+  version = "v0.4.1"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,6 +45,9 @@
   name = "github.com/tendermint/tmlibs"
   version = "~0.8.4"
 
+[[constraint]]
+  name = "github.com/confio/weave"
+  version = "~0.4.1"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,10 +26,6 @@
 
 
 [[constraint]]
-  name = "github.com/confio/weave"
-  version = "0.4.0"
-
-[[constraint]]
   name = "github.com/gogo/protobuf"
   version = "1.0.0"
 
@@ -37,21 +33,17 @@
   name = "github.com/stretchr/testify"
   version = "1.2.1"
 
-[[override]]
+[[constraint]]
   name = "github.com/tendermint/abci"
-  version = "0.10.0"
-
-[[override]]
-  name = "github.com/tendermint/go-wire"
-  version = "0.7.3"
+  version = "~0.10.3"
 
 [[override]]
   name = "github.com/tendermint/iavl"
-  version = "0.7.0"
+  version = "v0.8.0-rc0"
 
-[[override]]
+[[constraint]]
   name = "github.com/tendermint/tmlibs"
-  version = "0.7.0"
+  version = "~0.8.4"
 
 
 [prune]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TENDERMINT := ${GOBIN}/tendermint
 BUILDOUT ?= bov
 GOPATH ?= $$HOME/go
 
-TM_VERSION := v0.19.7
+TM_VERSION := v0.19.9
 
 # dont use `` in the makefile for windows compatibility
 NOVENDOR := $(shell go list ./...)
@@ -57,6 +57,7 @@ $(TENDERMINT):
 	cd $(GOPATH)/src/github.com/tendermint/tendermint && \
 		git checkout $(TM_VERSION) && \
 		make ensure_deps && make install && \
+		git checkout . && \
 		git checkout -
 
 protoc:


### PR DESCRIPTION
Need to tag weave version and lock it here I guess.